### PR TITLE
Provide author and title to calibre find result list

### DIFF
--- a/calibre-mode.el
+++ b/calibre-mode.el
@@ -292,13 +292,13 @@
            (read-char
             ;; render menu text here
             (let ((num-result (length calibre-item-list)))
-              (concat (format "%d matches for '%s'. pick target format?\n"
-                              num-result
-                              (getattr (car calibre-item-list) :book-title))
+              (concat (format "%d matches. Pick target:\n" num-result)
                       (mapconcat #'(lambda (idx)
                                      (let ((item (nth idx calibre-item-list)))
-                                       (format "   (%s) %s"
+                                       (format "   (%s) %s %s %s "
                                                (1+ idx)
+                                               (getattr item :author-sort)
+                                               (getattr item :book-title)
                                                (getattr item :book-format))))
                                  (number-sequence 0 (1- num-result))
                                  "\n"))))))

--- a/calibre-mode.el
+++ b/calibre-mode.el
@@ -176,70 +176,91 @@
              (deactivate-mark))
     (insert content)))
 
-;; define the result handlers here in the form of (hotkey description handler-function)
-;; where handler-function takes 1 alist argument containing the result record
-(setq calibre-handler-alist '(("o" "open"
-                               (lambda (res) (find-file-other-window (getattr res :file-path))))
-                              ("O" "open other frame"
-                               (lambda (res) (find-file-other-frame (getattr res :file-path))))
-                              ("v" "open with default viewer"
-                               (lambda (res)
-                                 (start-process "shell-process" "*Messages*" calibre-default-opener (getattr res :file-path))))
-                              ("x" "open with xournal"
-                               (lambda (res) (start-process "xournal-process" "*Messages*" "xournal"
-                                                            (let ((xoj-file-path (concat calibre-root-dir "/" (getattr res :book-dir) "/" (getattr res :book-name) ".xoj")))
-                                                              (if (file-exists-p xoj-file-path)
-                                                                  xoj-file-path
-                                                                (getattr res :file-path))))))
-                              ("s" "insert calibre search string"
-                               (lambda (res) (mark-aware-copy-insert (concat "title:\"" (getattr res :book-title) "\""))))
-                              ("c" "insert citekey"
-                               (lambda (res) (mark-aware-copy-insert (calibre-make-citekey res))))
-                              ("i" "get book information (SELECT IN NEXT MENU) and insert"
-                               (lambda (res)
-                                 (let ((opr (char-to-string (read-char
-                                                             ;; render menu text here
-                                                             (concat "What information do you want?\n"
-                                                                     "i : values in the book's `Ids` field (ISBN, DOI...)\n"
-                                                                     "d : pubdate\n"
-                                                                     "a : author list\n")))))
-                                   (cond ((string= "i" opr)
-                                          ;; stupidly just insert the plain text result
-                                          (mark-aware-copy-insert
-                                                   (calibre-chomp
-                                                    (calibre-query (concat "SELECT "
-                                                                           "idf.type, idf.val "
-                                                                           "FROM identifiers AS idf "
-                                                                           (format "WHERE book = %s" (getattr res :id)))))))
-                                         ((string= "d" opr)
-                                          (mark-aware-copy-insert
-                                                   (substring (getattr res :book-pubdate) 0 10)))
-                                         ((string= "a" opr)
-                                          (mark-aware-copy-insert
-                                                   (calibre-chomp (getattr res :author-sort))))
-                                         (t
-                                          (deactivate-mark)
-                                          (message "cancelled"))))
-
-                                 ))
-                              ("p" "insert file path"
-                               (lambda (res) (mark-aware-copy-insert (getattr res :file-path))))
-                              ("t" "insert title"
-                               (lambda (res) (mark-aware-copy-insert (getattr res :book-title))))
-                              ("j" "insert entry json"
-                               (lambda (res) (mark-aware-copy-insert (json-encode res))))
-                              ("X" "open as plaintext in new buffer (via pdftotext)"
-                               (lambda (res)
-                                 (let* ((citekey (calibre-make-citekey res)))
-                                   (let* ((pdftotext-out-buffer (get-buffer-create (format "pdftotext-extract-%s" (getattr res :id)))))
-                                     (set-buffer pdftotext-out-buffer)
-                                     (insert (shell-command-to-string (concat "pdftotext '" (getattr res :file-path) "' -")))
-                                     (switch-to-buffer-other-window pdftotext-out-buffer)
-                                     (beginning-of-buffer)))))
-                              ("q" "(or anything else) to cancel"
-                               (lambda (res)
-                                 (deactivate-mark)
-                                 (message "cancelled")))))
+;; Define the result handlers here in the form of (hotkey description
+;; handler-function) where handler-function takes 1 alist argument
+;; containing the result record.
+(setq calibre-handler-alist
+      '(("o" "open"
+         (lambda (res) (find-file-other-window (getattr res :file-path))))
+        ("O" "open other frame"
+         (lambda (res) (find-file-other-frame (getattr res :file-path))))
+        ("v" "open with default viewer"
+         (lambda (res)
+           (start-process "shell-process" "*Messages*" calibre-default-opener
+                          (getattr res :file-path))))
+        ("x" "open with xournal"
+         (lambda (res)
+           (start-process "xournal-process" "*Messages*" "xournal"
+                          (let ((xoj-file-path (concat calibre-root-dir "/"
+                                                       (getattr res :book-dir)
+                                                       "/"
+                                                       (getattr res :book-name)
+                                                       ".xoj")))
+                            (if (file-exists-p xoj-file-path)
+                                xoj-file-path
+                              (getattr res :file-path))))))
+        ("s" "insert calibre search string"
+         (lambda (res) (mark-aware-copy-insert
+                        (concat "title:\"" (getattr res :book-title) "\""))))
+        ("c" "insert citekey"
+         (lambda (res) (mark-aware-copy-insert (calibre-make-citekey res))))
+        ("i" "get book information (SELECT IN NEXT MENU) and insert"
+         (lambda (res)
+           (let ((opr
+                  (char-to-string
+                   (read-char
+                    ;; render menu text here
+                    (concat "What information do you want?\n"
+                            "i : values in the book's `Ids` field (ISBN, DOI...)\n"
+                            "d : pubdate\n"
+                            "a : author list\n")))))
+             (cond ((string= "i" opr)
+                    ;; stupidly just insert the plain text result
+                    (mark-aware-copy-insert
+                     (calibre-chomp
+                      (calibre-query
+                       (concat "SELECT "
+                               "idf.type, idf.val "
+                               "FROM identifiers AS idf "
+                               (format "WHERE book = %s" (getattr res :id)))))))
+                   ((string= "d" opr)
+                    (mark-aware-copy-insert
+                     (substring (getattr res :book-pubdate) 0 10)))
+                   ((string= "a" opr)
+                    (mark-aware-copy-insert
+                     (calibre-chomp (getattr res :author-sort))))
+                   (t
+                    (deactivate-mark)
+                    (message "cancelled"))))))
+        ("p" "insert file path"
+         (lambda (res) (mark-aware-copy-insert (getattr res :file-path))))
+        ("t" "insert title"
+         (lambda (res) (mark-aware-copy-insert (getattr res :book-title))))
+        ("g" "insert org link"
+         (lambda (res)
+           (insert (format "[[%s][%s]]"
+                           (getattr res :file-path)
+                           (concat (calibre-chomp (getattr res :author-sort))
+                                   ", "
+                                   (getattr res :book-title))))))
+        ("j" "insert entry json"
+         (lambda (res) (mark-aware-copy-insert (json-encode res))))
+        ("X" "open as plaintext in new buffer (via pdftotext)"
+         (lambda (res)
+           (let* ((citekey (calibre-make-citekey res)))
+             (let* ((pdftotext-out-buffer
+                     (get-buffer-create
+                      (format "pdftotext-extract-%s" (getattr res :id)))))
+               (set-buffer pdftotext-out-buffer)
+               (insert (shell-command-to-string (concat "pdftotext '"
+                                                        (getattr res :file-path)
+                                                        "' -")))
+               (switch-to-buffer-other-window pdftotext-out-buffer)
+               (beginning-of-buffer)))))
+        ("q" "(or anything else) to cancel"
+         (lambda (res)
+           (deactivate-mark)
+           (message "cancelled")))))
 
 (defun calibre-file-interaction-menu (calibre-item)
   (if (file-exists-p (getattr calibre-item :file-path))


### PR DESCRIPTION
This patch/PR provides the book author and title in addition to the (already) provided book format in the results/pick list from calibre-find. 